### PR TITLE
Update to Spigot 1.8 to allow PrisonRankup to be loaded

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,16 +26,16 @@
 
     <repositories>
         <repository>
-            <id>bukkit-repo</id>
-            <url>http://repo.bukkit.org/content/groups/public/</url>
+            <id>spigot-repo</id>
+            <url>https://hub.spigotmc.org/nexus/content/groups/public/</url>
         </repository>
     </repositories>
 
     <dependencies>
         <dependency>
-            <groupId>org.bukkit</groupId>
-            <artifactId>craftbukkit</artifactId>
-            <version>RELEASE</version>
+            <groupId>org.spigotmc</groupId>
+            <artifactId>spigot-api</artifactId>
+            <version>1.8.5-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/com/mojang/api/profiles/HttpProfileRepository.java
+++ b/src/main/java/com/mojang/api/profiles/HttpProfileRepository.java
@@ -1,17 +1,12 @@
 package com.mojang.api.profiles;
 
-import com.mojang.api.http.BasicHttpClient;
-import com.mojang.api.http.HttpBody;
-import com.mojang.api.http.HttpClient;
-import com.mojang.api.http.HttpHeader;
-import net.minecraft.util.com.google.gson.Gson;
+import com.google.gson.Gson;
+import com.mojang.api.http.*;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
+import java.util.*;
 
 public class HttpProfileRepository implements ProfileRepository {
 


### PR DESCRIPTION
PrisonRankup would crash each time I loaded it. Here, I have updated the GSON imports to use the version of GSON included with Spigot 1.8. (Sorry about the PR in Mojang's repo)
